### PR TITLE
Work around silly issue with case-insensitive filesystems.

### DIFF
--- a/src/library/markdown.jl
+++ b/src/library/markdown.jl
@@ -1,4 +1,5 @@
 if VERSION < v"0.4.0-dev"
+    require(Pkg.dir("Markdown", "src", "Markdown.jl"))
     import Markdown
 else
     const Markdown = Base.Markdown


### PR DESCRIPTION
This is really a Julia issue (https://github.com/JuliaLang/julia/issues/9079, maybe others?), but if you follow the readme on a system with a case-insensitive filesystem (like OSX, by default), escher will hang because `import Markdown` will try to load `examples/markdown.jl`.

Obviously this isn't great, because you could still accidentally sabotage escher by naming a file after anything it imports, but a proper solution should be in julia, like looking in the package directory before trying to load from the working directory.