### PR TITLE
Update Escher.jl - fix warnings on 0.4

### DIFF
--- a/src/Escher.jl
+++ b/src/Escher.jl
@@ -17,7 +17,7 @@ using Patchwork
 using Reactive
 using JSON
 
-import Base: convert, writemime, <<, *, /, +, -
+import Base: convert, writemime, *, /, +, -
 
 # Polymer Setup
 custom_elements() =

--- a/src/Escher.jl
+++ b/src/Escher.jl
@@ -17,7 +17,7 @@ using Patchwork
 using Reactive
 using JSON
 
-import Base: convert, writemime
+import Base: convert, writemime, <<, *, /, +, -
 
 # Polymer Setup
 custom_elements() =


### PR DESCRIPTION
Fix warnings on latest 0.4:

```
julia> using Escher
WARNING: module Patchwork should explicitly import << from Base
WARNING: module Escher should explicitly import * from Base
WARNING: module Escher should explicitly import / from Base
WARNING: module Escher should explicitly import + from Base
WARNING: module Escher should explicitly import - from Base
```