### PR TITLE
WIP: switch to Colors package (do not merge yet)

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,6 +1,6 @@
 julia 0.3
 ArgParse
-Color
+Colors
 Compat
 Dates
 JSON

--- a/docs/behavior-api.jl
+++ b/docs/behavior-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 
 include("helpers/page.jl")

--- a/docs/content-api.jl
+++ b/docs/content-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/embellishment-api.jl
+++ b/docs/embellishment-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/helpers/doc.jl
+++ b/docs/helpers/doc.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 import Escher: @d
 
@@ -149,6 +149,6 @@ end
 
 showdocs(fns) =
    vbox(intersperse([vskip(2em), 
-        border([bottom], solid, 1px, color("#ddd"), empty),
+        border([bottom], solid, 1px, colorant"#ddd", empty),
         vskip(2em)],
         map(showdoc, fns)))

--- a/docs/index.jl
+++ b/docs/index.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 import Compose: compose, context, polygon
 using Lazy
 using Gadfly
@@ -63,7 +63,7 @@ $(vskip(1em))
 $(
 
 vbox(
-hline(color=color("#e1e1e1")),
+hline(color=colorant"#e1e1e1"),
 vskip(2em),
 Escher.fontsize(2em,
      "With Escher you can build beautiful Web UIs entirely in Julia.") |>
@@ -73,7 +73,7 @@ Escher.fontsize(2em,
         maxwidth(15em) |>
         x -> hbox(flex(), x, flex()),
 vskip(2em),
-hline(color=color("#e1e1e1")),
+hline(color=colorant"#e1e1e1"),
 )
 )
 $(vskip(3em))
@@ -216,7 +216,7 @@ plot(z=(x,y) -> x*exp(-(x-int(x))^2-y^2),
 
 ```julia
 using Compose
-using Color
+using Colors
 
 function sierpinski(n)
     if n == 0
@@ -503,7 +503,7 @@ part2 = md"""
 This is Minesweeper in about 80 SLOC!
 
 ```julia
-using Color
+using Colors
 using Lazy
 
 #### Model ####

--- a/docs/layout-api.jl
+++ b/docs/layout-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/layout2-api.jl
+++ b/docs/layout2-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/reactive_programming.jl
+++ b/docs/reactive_programming.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 
@@ -68,7 +68,7 @@ end)
 Let's say we want to use the slider to set the hue of a rectangle in the UI. The statement of this problem naturally guides the next step -- we need a function that given the slider value, returns a rectangle with a specific hue.
 
 ```julia
-    using Color
+    using Colors
 
     with_hue(hue, tile=size(6em, 6em, empty)) =
         fillcolor(HSV(hue, 0.6, 0.6), tile) # HSV color space
@@ -82,7 +82,7 @@ Let's see if this function actually works by drawing colored squares for hues in
 
 $(begin
     with_hue(hue, tile=size(4em, 4em, empty)) =
-        fillcolor(Color.HSV(hue, 0.6, 0.6), tile)
+        fillcolor(Colors.HSV(hue, 0.6, 0.6), tile)
 
     hbox(intersperse(hskip(1em), map(with_hue, 0:45:270))) |> hbox |> packitems(center) |> fig
 end)

--- a/docs/signal-api.jl
+++ b/docs/signal-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/slideshow-api.jl
+++ b/docs/slideshow-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/tex-api.jl
+++ b/docs/tex-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/typography-api.jl
+++ b/docs/typography-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/util-api.jl
+++ b/docs/util-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/docs/widgets-api.jl
+++ b/docs/widgets-api.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 include("helpers/page.jl")
 include("helpers/doc.jl")

--- a/examples/layout.jl
+++ b/examples/layout.jl
@@ -1,6 +1,6 @@
 
 # An infinite number of mathematicians walk into a bar...
-using Color
+using Colors
 using Compat
 
 colors = distinguishable_colors(9)

--- a/examples/minesweeper.jl
+++ b/examples/minesweeper.jl
@@ -1,5 +1,5 @@
 using Compat # for Nullable
-using Color
+using Colors
 using Lazy
 
 #### Model ####

--- a/src/basics/embellishment.jl
+++ b/src/basics/embellishment.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 export noborder,
        dotted,
@@ -26,7 +26,7 @@ const allsides = Side[]
                `left`, `right`, `top` and `bottom`. By default the border color
                is set for all sides."""
     )
-    arg(color::ColorValue, doc="The color.")
+    arg(color::Color, doc="The color.")
     curry(tile::Tile, doc="The tile to border.")
 end
 render(t::BorderColor, state) =
@@ -37,7 +37,7 @@ render(t::BorderColor, state) =
     )
 
 @api borderwidth => (BorderWidth <: Tile) begin
-    doc("Set the border width.") 
+    doc("Set the border width.")
     typedarg(
         sides::AbstractArray=allsides,
         doc=md"""An array of sides to set the border width for. Valid values are
@@ -89,7 +89,7 @@ border(
     sides::AbstractArray,
     style::StrokeStyle,
     width::Length,
-    color::ColorValue,
+    color::Color,
     tile
 ) =
     borderstyle(sides, style,
@@ -99,7 +99,7 @@ border(
 border(sides::AbstractArray, style, width, color) =
     tile -> border(sides, style, width, color, tile)
 
-border(style::StrokeStyle, width::Length, color::ColorValue, tile) =
+border(style::StrokeStyle, width::Length, color::Color, tile) =
     borderstyle(allsides, style,
         borderwidth(allsides, width,
             bordercolor(allsides, color, tile)))
@@ -112,7 +112,7 @@ border(style::StrokeStyle, width, color) =
     typedarg(sides::AbstractArray=allsides, doc="An array of sides to set the border for. Valid values are `left`, `right`, `top` and `bottom`. By default the border is set for all sides.")
     arg(style::StrokeStyle, doc="The border style. Valid values are `noborder`, `dotted`, `dashed` and `solid`.")
     arg(width::Length, doc="The width.")
-    arg(color::ColorValue, doc="The color.")
+    arg(color::Color, doc="The color.")
     curry(tile::Tile, doc="The tile to border.")
 end
 const default_border_color = RGB(0.6, 0.6, 0.6)
@@ -124,7 +124,7 @@ hline(;style=solid, width=1px, color=default_border_color) =
     doc("Create a horizontal line. Returns a bordered tile of height 0.")
     kwarg(style::StrokeStyle, doc="The line style. Valid values are `noborder`, `dotted`, `dashed` and `solid`.")
     kwarg(width::Length, doc="The width.")
-    kwarg(color::ColorValue, doc="The color.")
+    kwarg(color::Color, doc="The color.")
 end
 
 vline(;style=solid, width=1px, color=default_border_color) =
@@ -134,7 +134,7 @@ vline(;style=solid, width=1px, color=default_border_color) =
     doc("Create a vertical line. Returns a bordered tile of width 0.")
     kwarg(style::StrokeStyle, doc="The line style. Valid values are `noborder`, `dotted`, `dashed` and `solid`.")
     kwarg(width::Length, doc="The width.")
-    kwarg(color::ColorValue, doc="The color.")
+    kwarg(color::Color, doc="The color.")
 end
 
 ## RoundRects
@@ -161,17 +161,16 @@ render(t::RoundedRect, state) =
     kwarg(offset::(@compat Tuple{Length, Length})=(0px, 0px), doc="The offset. Displaces the shadow relative to the tile.")
     kwarg(blur_radius::Length=5px, doc="The radius for blurring.")
     kwarg(spread_radius::Length=5px, doc="The radius for spreading.")
-    kwarg(color::ColorValue=color("black"), doc="Base color of the shadow.")
+    kwarg(color::Color=parse(Colorant,"black"), doc="Base color of the shadow.")
 end
 
 ## Fill color
 
 @api fillcolor => (FillColor <: Tile) begin
     doc("Fill a tile with a color.")
-    arg(color::ColorValue, doc="The color.")
+    arg(color::Color, doc="The color.")
     curry(tile::Tile, doc="The tile.")
 end
 
 render(t::FillColor, state) =
     render(t.tile, state) & style(@d(:backgroundColor => render_color(t.color)))
-

--- a/src/basics/macros.jl
+++ b/src/basics/macros.jl
@@ -292,16 +292,16 @@ const escher_meta = Dict()
     @api border => (Bordered{T <: Side} <: Tile) begin
         arg(side::T)
         curry(tile::Tile)
-        kwarg(color::ColorValue=color("black"))
+        kwarg(color::Color=colorant"black")
     end
  
  Should result in:
 
      immutable Bordered{T <: Side} <: Tile
          tile::Tile
-         color::ColorValue
+         color::Color
      end
-     border(side, tiles; color::ColorValue=color("black")) = Bordered(side, tiles, color)
+     border(side, tiles; color::Color=colorant"black") = Bordered(side, tiles, color)
      border(side; kwargs...) = tiles -> border(tiles; kwargs...)
 
 """ -> 

--- a/src/basics/typography.jl
+++ b/src/basics/typography.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 export plaintext,
        fontfamily,
        fontsize,
@@ -91,7 +91,7 @@ const allowed_font_weights = 100:100:900
 @api fontweight => (WithFontWeight{T <: Union(Int, FontWeight)} <: Tile) begin
     doc("Set the font weight of text in one or more tiles.")
     arg(
-        weight::T, 
+        weight::T,
         doc="Font weight. Valid font weights are multiplies of 100 between 100 and 900."
     )
     curry(
@@ -113,12 +113,12 @@ render{T <: FontWeight}(t::WithFontWeight{T}, state) =
 
 @api fontcolor => (FontColor <: Tile) begin
     doc("Set the font color.")
-    arg(color::ColorValue, doc="The color.")
+    arg(color::Color, doc="The color.")
     curry(tiles::TileList, doc="A tile or a vector of tiles.")
 end
 
-fontcolor(c::String) = fontcolor(color(c))
-fontcolor(c::String, tiles) = fontcolor(color(c), tiles)
+fontcolor(c::String) = fontcolor(parse(Colorant, c))
+fontcolor(c::String, tiles) = fontcolor(parse(Colorant, c), tiles)
 
 render(t::FontColor, state) =
     wrapmany(t.tiles, :span, state) & style(@d(:color => render_color(t.color)))
@@ -142,7 +142,7 @@ end
 @api fonttype => (WithFontType <: Tile) begin
     doc("Set the font type.")
     arg(
-        typ::FontType, 
+        typ::FontType,
         doc=md"""The font type. Valid font types are `serif`, `sanserif`,
                  `slabserif` and `monospace`."""
     )
@@ -170,7 +170,7 @@ classes(::Italic) = "font-italic"
 @api fontstyle => (WithFontStyle <: Tile) begin
     doc("Set the font style.")
     arg(
-        style::FontStyle, 
+        style::FontStyle,
         doc=md"The font style. Valid font styles are `normal`, `slanted` and `italic`."
     )
     curry(tiles::TileList, doc="A tile or a vector of tiles.")
@@ -250,12 +250,12 @@ heading(n::Int) = t -> heading(n,t)
 title(n::Int, txt) = class("title-$n", txt)
 
 @apidoc title => (Class <: Tile) begin
-    doc(md"Create a title.") 
+    doc(md"Create a title.")
     arg(
         level::Int,
         doc="Title level. More is bigger. Valid values are integers 1 to 4."
     )
-    curry(tile::TileList, doc="A tile or a vector of tiles.") 
+    curry(tile::TileList, doc="A tile or a vector of tiles.")
 end
 
 h1(txt) = heading(1, txt)
@@ -264,9 +264,9 @@ h3(txt) = heading(3, txt)
 h4(txt) = heading(4, txt)
 
 @apidoc heading => (Class <: Tile) begin
-    doc(md"Create a heading. You can use `h1`, `h2`, `h3`, `h4` for brevity.") 
+    doc(md"Create a heading. You can use `h1`, `h2`, `h3`, `h4` for brevity.")
     arg(level::Int, doc="Heading level.")
-    curry(tile::TileList, doc="A tile or a vector of tiles.") 
+    curry(tile::TileList, doc="A tile or a vector of tiles.")
 end
 
 blockquote(txt) = class("blockquote", txt, forcewrap=true, wrap=:blockquote)

--- a/src/basics/util.jl
+++ b/src/basics/util.jl
@@ -1,4 +1,4 @@
-using Color
+using Colors
 
 # Dict macro
 macro d(xs...)
@@ -9,8 +9,8 @@ macro d(xs...)
   end
 end
 
-convert(::Type{ColorValue}, s::String) =
-    color(s)
+convert(::Type{Color}, s::String) =
+    parse(Colorant, s)
 
 render_color(c) = string("#" * hex(c))
 
@@ -80,7 +80,7 @@ render(c::Class, state) =
                c.class)
 
 @doc """
-given a sentinal, vector of parts, prefix, suffix and a value, 
+given a sentinal, vector of parts, prefix, suffix and a value,
 
 if the vector of parts is referentially equal to the sentinal, then returns
     [prefix * suffix => value]
@@ -101,4 +101,3 @@ teeprint(x, fn=println) = begin
     fn(x)
     x
 end
-

--- a/test/macros.jl
+++ b/test/macros.jl
@@ -1,32 +1,32 @@
 import Escher: @api
 
-@api test1 => TestType1 begin
+@api test1 --> TestType1 begin
     arg(a::FloatingPoint)
 end
-@fact test1(3) => TestType1(3.0)
+@fact test1(3) --> TestType1(3.0)
 
-@api testsub => TestSubType <: Number begin
+@api testsub --> TestSubType <: Number begin
     arg(a::FloatingPoint)
 end
-@fact testsub(3) => TestSubType(3.0)
+@fact testsub(3) --> TestSubType(3.0)
 
-@api test2 => TestType2 begin
+@api test2 --> TestType2 begin
     typedarg(a::FloatingPoint)
     arg(b::Int)
     curry(x::Int)
 end
 
-println(macroexpand(:(@api test2 => TestType2 begin
+println(macroexpand(:(@api test2 --> TestType2 begin
     typedarg(a::FloatingPoint)
     arg(b::Int)
     curry(x::Int)
 end)))
 
 @fact_throws test2(2, 3, 4) # Because 2 should be float
-@fact test2(2.0, 3, 4) => TestType2(2.0, 3, 4)
-@fact test2(2.0, 3)(4) => TestType2(2.0, 3, 4)
+@fact test2(2.0, 3, 4) --> TestType2(2.0, 3, 4)
+@fact test2(2.0, 3)(4) --> TestType2(2.0, 3, 4)
 
-@api test3 => TestType3 begin
+@api test3 --> TestType3 begin
     typedarg(a::FloatingPoint)
     arg(b::Int)
     curry(x::Int)
@@ -35,17 +35,17 @@ end)))
 end
 
 @fact_throws test3(2, 3, 4) # Because 2 should be float
-@fact test3(2.0, 3, 4) => TestType3(2.0, 3, 4, "black", 1)
-@fact test3(2.0, 3)(4) => TestType3(2.0, 3, 4, "black", 1)
-@fact test3(2.0, 3, 4, p=:white) => TestType3(2.0, 3, 4, :white, 1)
-@fact test3(2.0, 3, q=5.0)(4) => TestType3(2.0, 3, 4, "black", 5.0)
+@fact test3(2.0, 3, 4) --> TestType3(2.0, 3, 4, "black", 1)
+@fact test3(2.0, 3)(4) --> TestType3(2.0, 3, 4, "black", 1)
+@fact test3(2.0, 3, 4, p=:white) --> TestType3(2.0, 3, 4, :white, 1)
+@fact test3(2.0, 3, q=5.0)(4) --> TestType3(2.0, 3, 4, "black", 5.0)
 @fact_throws test3(2.0, 5, 4, q=1)
 
 abstract A
 immutable B<:A end
 
 #@show macroexpand(:(
-@api test4 => Test4{P <: A} <: Tile begin
+@api test4 --> Test4{P <: A} <: Tile begin
     typedarg(a::AbstractArray=Integer[])
     arg(b::P)
     curry(c::Int)
@@ -53,7 +53,7 @@ end
 #))
 println(test4(B())(2))
 
-@api code => Code <: A begin
+@api code --> Code <: A begin
     arg(language::String="julia")
     arg(code::Any)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,6 @@
 using Escher
 using FactCheck
+using Compat
 
 include("macros.jl")
 FactCheck.exitstatus()


### PR DESCRIPTION
Well, sadly I did not quite figure out how to get this to work:
```jl
julia> include("runtests.jl")
begin 
    immutable TestType2
        a::FloatingPoint
        b::Int
        x::Int
    end
    test2(#1320#a::FloatingPoint,#1321#b,#1322#x) = TestType2(#1320#a,#1321#b,#1322#x)
    test2(#1323#a::FloatingPoint,#1324#b) = (#1325#x->begin  # /home/tim/.julia/v0.3/Escher/src/basics/macros.jl, line 224:
                TestType2(#1323#a,#1324#b,#1325#x)
            end)
    Escher.escher_meta[test2] = $(Expr(:dict, :(:doc=>""), :(:name=>test2), :(:type=>:TestType2), :(:args=>[merge({:type=>:FloatingPoint,:curried=>false,:coerced=>false,:kwarg=>false,:name=>:a},$(Expr(:dict, :(:doc=>"")))),merge({:type=>:Int,:curried=>false,:coerced=>true,:kwarg=>false,:name=>:b},$(Expr(:dict, :(:doc=>"")))),merge({:type=>:Int,:curried=>true,:coerced=>true,:kwarg=>false,:name=>:x},$(Expr(:dict, :(:doc=>""))))])))
end
Test4{B}(Integer[],B(),2)
ERROR: FactCheck finished with 4 non-successful tests.
 in error at error.jl:21
 in exitstatus at /home/tim/.julia/v0.3/FactCheck/src/FactCheck.jl:500
 in include at ./boot.jl:245
 in include_from_node1 at ./loading.jl:128
while loading /home/tim/.julia/v0.3/Escher/test/runtests.jl, in expression starting on line 6
```
You can trigger it with `test3(2.0, 3, 4)`. Any ideas?

Once this is working, you still shouldn't merge until "C-day" (hopefully Tuesday or Wednesday, if we resolve the problems in time).
