### PR TITLE
Fix selection behavior for polymer 1.0

### DIFF
--- a/assets/behavior.html
+++ b/assets/behavior.html
@@ -170,8 +170,7 @@ Polymer({
 
     this.setId()
     var handler = function (ev) {
-      var val = self.multi ?
-        (elem.selectedValues || []) :
+      var val = self.multi ? (elem.selectedValues || []) :
         (elem.selected || 0)
 
       self.update(elem, self.name, val)

--- a/src/basics/behavior.jl
+++ b/src/basics/behavior.jl
@@ -131,9 +131,10 @@ end
 
 render(t::Selectable, state) =
     render(t.tile, state) <<
-        Elem("selectable-behavior", multi = t.multi,
+        Elem("selectable-behavior",
             attributes = @d(
                 :name=>t.name,
+		:multi=>boolattr( t.multi ),
                 :selector=>t.selector                
             )
         )

--- a/src/basics/behavior.jl
+++ b/src/basics/behavior.jl
@@ -131,11 +131,10 @@ end
 
 render(t::Selectable, state) =
     render(t.tile, state) <<
-        Elem("selectable-behavior",
+        Elem("selectable-behavior", multi = t.multi,
             attributes = @d(
                 :name=>t.name,
-                :selector=>t.selector,
-                :multi=>t.multi
+                :selector=>t.selector                
             )
         )
 
@@ -231,4 +230,3 @@ wire(a, b, chan, attribute) =
     arg(chan::Symbol, doc="The name of the channel.")
     arg(attr::Symbol, doc="The attribute/property to connect.")
 end
-

--- a/src/library/layout2.jl
+++ b/src/library/layout2.jl
@@ -56,7 +56,7 @@ wrapbehavior(w::IconButton) =
     clickable(w, name=w.name)
 
 
-abstract Selection <: Widget 
+abstract Selection <: Widget
 
 @api pages => (Pages <: Selection) begin #FIXME: Why is this a widget?
     doc("A set of pages. Only one selected page will be visible at any given time.")
@@ -67,7 +67,7 @@ end
 
 render(ps::Pages, state) =
     Elem("iron-pages",
-        map(t -> Elem("section", render(t, state)), ps.pages.tiles),
+        map(t -> Elem("div", render(t, state)), ps.pages.tiles),
         attributes = @d(:selected=>ps.selected-1))
 
 @api tabs => (Tabs <: Selection) begin
@@ -225,4 +225,3 @@ render(dm::DropdownMenu, state) = begin
     )
 end
 wrapbehavior(d::DropdownMenu) = selectable(d, name=d.name, selector=".dropdown-content")
-


### PR DESCRIPTION
Polymer 1.0 defines pages as div elements in current examples.  Virtual patch of attribute boolean values fails with sneaky dom and results in an always true value. This breaks the tabbed pages example. 