### PR TITLE
Add access to julia file (work) directory

### DIFF
--- a/src/basics/window.jl
+++ b/src/basics/window.jl
@@ -16,7 +16,7 @@ Window(;
     dir="ltr") =
     Window(Input{Bool}(alive), Input{Any}(dimension), Input{Any}(route), "ltr", Input{Any}("basics"))
 
-resolve_asset(slug::String, prefix="/assets", joinfn=(x, y) -> x * "/" * y) = begin
+resolve_asset(slug::String, prefix="/escher/assets", joinfn=(x, y) -> x * "/" * y) = begin
     path = Pkg.dir("Escher", "assets", slug * ".html")
     if isfile(path)
         return joinfn(prefix, "$slug.html")

--- a/src/basics/window.jl
+++ b/src/basics/window.jl
@@ -16,15 +16,6 @@ Window(;
     dir="ltr") =
     Window(Input{Bool}(alive), Input{Any}(dimension), Input{Any}(route), "ltr", Input{Any}("basics"))
 
-resolve_asset(slug::String, prefix="/escher/assets", joinfn=(x, y) -> x * "/" * y) = begin
-    path = Pkg.dir("Escher", "assets", slug * ".html")
-    if isfile(path)
-        return joinfn(prefix, "$slug.html")
-    else
-        error("Asset file $path doesn't exist")
-    end
-end
-
 resolve_asset(tup :: (@compat Tuple{String, String}), prefix ="/pkg", joinfn=(x, y) -> x * "/" * y) = begin
     pkg = tup[1]
     slug = tup[2]
@@ -35,3 +26,5 @@ resolve_asset(tup :: (@compat Tuple{String, String}), prefix ="/pkg", joinfn=(x,
         error("Asset file $path doesn't exist")
     end
 end
+
+resolve_asset(slug::String) = resolve_asset(("Escher", slug))

--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -223,7 +223,7 @@ function escher_serve(port=5555, dir="")
         Mux.defaults,
         route("escher/assets", Mux.files(Pkg.dir("Escher", "assets")), Mux.notfound()),
         route("assets", Mux.files(dir), Mux.notfound()),
-        route("pkg/:pkg", packagefiles("escher/assets"), Mux.notfound()),
+        route("pkg/:pkg", packagefiles("assets"), Mux.notfound()),
         route("/:file", req -> setup_socket(req[:params][:file])),
         route("/", req -> setup_socket("index.jl")),
         Mux.notfound(),

--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -45,7 +45,7 @@ function setup_socket(file)
         """)
     # Include the basics
     write(io, "<script>", Patchwork.js_runtime(), "</script>")
-    write(io, """<script src="pkg/Escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
+    write(io, """<script src="/pkg/Escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
     write(io, """<link rel="import" href="$(Escher.resolve_asset("basics"))">""")
 
     write(io, """</head> <body fullbleed unresolved>""")

--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -45,7 +45,7 @@ function setup_socket(file)
         """)
     # Include the basics
     write(io, "<script>", Patchwork.js_runtime(), "</script>")
-    write(io, """<script src="/escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
+    write(io, """<script src="pkg/Escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
     write(io, """<link rel="import" href="$(Escher.resolve_asset("basics"))">""")
 
     write(io, """</head> <body fullbleed unresolved>""")
@@ -221,9 +221,8 @@ function escher_serve(port=5555, dir="")
     # App
     @app static = (
         Mux.defaults,
-        route("escher/assets", Mux.files(Pkg.dir("Escher", "assets")), Mux.notfound()),
-        route("assets", Mux.files(dir), Mux.notfound()),
         route("pkg/:pkg", packagefiles("assets"), Mux.notfound()),
+        route("assets", Mux.files(dir), Mux.notfound()),
         route("/:file", req -> setup_socket(req[:params][:file])),
         route("/", req -> setup_socket("index.jl")),
         Mux.notfound(),

--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -45,7 +45,7 @@ function setup_socket(file)
         """)
     # Include the basics
     write(io, "<script>", Patchwork.js_runtime(), "</script>")
-    write(io, """<script src="/pkg/Escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
+    write(io, """<script src="/pkg/Escher/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
     write(io, """<link rel="import" href="$(Escher.resolve_asset("basics"))">""")
 
     write(io, """</head> <body fullbleed unresolved>""")

--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -45,7 +45,7 @@ function setup_socket(file)
         """)
     # Include the basics
     write(io, "<script>", Patchwork.js_runtime(), "</script>")
-    write(io, """<script src="/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
+    write(io, """<script src="/escher/assets/bower_components/webcomponentsjs/webcomponents.min.js"></script>""")
     write(io, """<link rel="import" href="$(Escher.resolve_asset("basics"))">""")
 
     write(io, """</head> <body fullbleed unresolved>""")
@@ -212,8 +212,8 @@ uisocket(dir) = (req) -> begin
 end
 
 # Return files from the requested package, in the supplied directory
-packagefiles(dir, dirs = true) =
-  branch(req -> Mux.validpath(Pkg.dir(req[:params][:pkg], dir ), joinpath(req[:path]...), dirs=dirs),
+packagefiles(dir, dirs=true) =
+  branch(req -> Mux.validpath(Pkg.dir(req[:params][:pkg], dir), joinpath(req[:path]...), dirs=dirs),
          req -> Mux.fresp(joinpath(Pkg.dir(req[:params][:pkg], dir), req[:path]...)))
 
 
@@ -221,8 +221,9 @@ function escher_serve(port=5555, dir="")
     # App
     @app static = (
         Mux.defaults,
-        route("assets", Mux.files(Pkg.dir("Escher", "assets")), Mux.notfound()),
-        route("pkg/:pkg", packagefiles( "assets"), Mux.notfound()),
+        route("escher/assets", Mux.files(Pkg.dir("Escher", "assets")), Mux.notfound()),
+        route("assets", Mux.files(dir), Mux.notfound()),
+        route("pkg/:pkg", packagefiles("escher/assets"), Mux.notfound()),
         route("/:file", req -> setup_socket(req[:params][:file])),
         route("/", req -> setup_socket("index.jl")),
         Mux.notfound(),


### PR DESCRIPTION
Fixes https://github.com/shashi/Escher.jl/issues/81

This moves the access to the `Escher/assets` directory from `assets` to `escher/assets` and adds access to the user working path (from where the julia files are loaded) under the `assets` name.

Now you can load images directly from the directory of your julia file without the need of the `Images` package, which makes specially easy to load svg files.

For example, if you have a file `image.svg` in the same path of your escher/julia file, you can load the image as `image("assets/image.svg")`.