### PR TITLE
Make markdown example correspond to the output.

### DIFF
--- a/docs/index.jl
+++ b/docs/index.jl
@@ -165,6 +165,7 @@ function main(window)
 
 - Create *universe*
 - Make a *pie*
+- Interpolate $\KaTeX$
 \"\"\"
 end
 ```


### PR DESCRIPTION
The text of one of the examples on escher-jl.org doesn't match the code that's actually running.