### PR TITLE
Implementation of floatinglabel for the textinput widget (Issue 102)

### DIFF
--- a/src/library/widgets.jl
+++ b/src/library/widgets.jl
@@ -247,6 +247,7 @@ render(t::TextInput, state) = begin
                  "auto-validate" => boolattr(true),
                  "disabled" => boolattr(t.disabled),
                  "char-counter" => boolattr(t.charcounter),
+                 "no-label-float" => boolattr(!t.floatinglabel),
                  )
              )
 end


### PR DESCRIPTION
This change is a proposed fix for issue #102.  It is an implementation of control of the `floatinglabel` option for the `textinput` widget.

This fix follows the pattern used to implement some of the other boolean arguments for this widget.  Note that the corresponding property of the polymer `paper-input` element is `noLabelFloat`, which has the opposite sense to `floatinglabel`, so this argument is negated in its assignment to `no-label-float`.