### PR TITLE
Fix example form.jl

### DIFF
--- a/examples/form.jl
+++ b/examples/form.jl
@@ -17,6 +17,6 @@ function main(window)
             intent(s, form) >>> inp,
             vskip(2em),
             string(dict)
-        ) |> pad(2em)
+        ) |> Escher.pad(2em)
     end
 end


### PR DESCRIPTION
`pad(2cm)` -> `Escher.pad(2cm)`