### PR TITLE
Fix ambiguous foreach warning

### DIFF
--- a/src/cli/serve.jl
+++ b/src/cli/serve.jl
@@ -158,7 +158,7 @@ uisocket(dir) = (req) -> begin
 
     window = Window(dimension=(w*px, h*px))
 
-    foreach(asset -> write(sock, JSON.json(import_cmd(asset))),
+    Reactive.foreach(asset -> write(sock, JSON.json(import_cmd(asset))),
          window.assets)
 
     main = loadfile(file)


### PR DESCRIPTION
I realize #117 exists, but it doesn't appear it's going to be merged any time soon until all the changes are separated. 

In the meantime, this one line, 8 character change is the minimum for 'Hello, World' functionality of `examples\layout2.jl`.
<img width="1867" alt="screen shot 2016-04-07 at 9 15 13 am" src="https://cloud.githubusercontent.com/assets/2762787/14352191/4445c102-fca1-11e5-9c9f-cad4345aee2c.png">

It'd be great if this could be merged and tagged quickly, so that Escher isn't in a broken state for 0.4 daily