### PR TITLE
fix concatenation in minesweeper

### DIFF
--- a/examples/minesweeper.jl
+++ b/examples/minesweeper.jl
@@ -50,7 +50,7 @@ board_signal = flatten(
 ### View ###
 
 
-colors = ["#fff", colormap("reds", 7)]
+colors = ["#fff"; colormap("reds", 7)]
 
 box(content, color) =
     inset(Escher.middle,


### PR DESCRIPTION
This removes a deprecation warning when running the minesweeper example.

```
WARNING: [a,b] concatenation is deprecated; use [a;b] instead
```
