### PR TITLE
Replace `_print` with `lower`

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -3,7 +3,7 @@ ArgParse
 Colors
 Compat
 Dates
-JSON
+JSON 0.7
 Markdown
 Mux 0.1.0
 Reactive 0.3.0

--- a/src/basics/length.jl
+++ b/src/basics/length.jl
@@ -44,4 +44,4 @@ convert(::Type{Length}, x::Real) =
 
 Base.string{unit}(x::Length{unit}) = string(x.value, unit)
 Base.string(x::Length{:cent}) = string(x.value, :%)
-JSON._print(io::IO, ::JSON.State, x::Length) = Base.print(io, "\"", string(x), "\"")
+JSON.lower(x::Length) = string(x)


### PR DESCRIPTION
In JSON v0.7.0 and beyond, overloads of `_print` are deprecated in favour of overloading the simpler `lower` function.

The new JSON tag is not yet merged; see https://github.com/JuliaLang/METADATA.jl/pull/5988. I'll ping you when it is.