### PR TITLE
Hasstate for multiple attributes/triggers + immediate values on slider

### DIFF
--- a/assets/behavior.html
+++ b/assets/behavior.html
@@ -48,6 +48,52 @@ Polymer({
 </dom-module>
 
 <dom-module
+  id="watch-states" >
+
+  <template><content></content></template>
+
+<script>
+
+Polymer({
+  is: "watch-states",
+  behaviors: [EscherMixins.LifeCycle, EscherMixins.ReactiveSignal],
+
+  properties: {
+    triggers: {
+      type: Object,
+      value: {value: "change"}
+    }
+  },
+
+  getAttr: function (elem, attr) {
+    var val = elem[attr]
+    return (typeof val !== "undefined") ?
+      val : elem.getAttribute(attr)
+  },
+
+  getValue: function (attr) {
+     return this.getAttr(this.findElem(), attr)
+  },
+
+  domInit: function () {
+    var self = this, elem = this.findElem()
+
+    this.setId()
+
+    for (var attr in this.triggers) {
+      var trigger = this.triggers[attr]
+      elem.addEventListener(trigger, function (ev) {
+        self.update(elem, self.getValue(attr))
+      })
+    }
+  }
+})
+
+</script>
+
+</dom-module>
+
+<dom-module
   id="clickable-behavior">
 
   <template><content></content></template>

--- a/assets/behavior.html
+++ b/assets/behavior.html
@@ -1,53 +1,6 @@
 <link rel="import" href="bower_components/iron-a11y-keys/iron-a11y-keys.html">
 
 <dom-module
-  id="watch-state" >
-
-  <template><content></content></template>
-
-<script>
-
-Polymer({
-  is: "watch-state",
-  behaviors: [EscherMixins.LifeCycle, EscherMixins.ReactiveSignal],
-
-  properties: {
-    attr: {
-      type: String,
-      value: "value"
-    },
-    trigger: {
-      type: String,
-      value: "change"
-    }
-  },
-
-  getAttr: function (elem, attr) {
-    var val = elem[attr]
-    return (typeof val !== "undefined") ?
-      val : elem.getAttribute(attr)
-  },
-
-  getValue: function () {
-     return this.getAttr(this.findElem(), this.attr)
-  },
-
-  domInit: function () {
-    var self = this, elem = this.findElem()
-
-    this.setId()
-
-    elem.addEventListener(this.trigger, function (ev) {
-      self.update(elem, self.getValue())
-    })
-  }
-})
-
-</script>
-
-</dom-module>
-
-<dom-module
   id="watch-states" >
 
   <template><content></content></template>

--- a/src/basics/behavior.jl
+++ b/src/basics/behavior.jl
@@ -1,4 +1,5 @@
 export hasstate,
+       hasstates,
        keypress,
        Key,
        nokey,
@@ -38,6 +39,31 @@ render(t::WithState, state) =
             "watch-state", attributes=@d(
                 :attr=>t.attr,
                 :trigger=>t.trigger,
+                :selector=>t.selector,
+            )
+        )
+
+@api hasstates => (WithStates <: Behavior) begin
+    doc("Watch for changes to attributes/properties.")
+    arg(tile::Tile, doc="Tile to watch.")
+    kwarg(
+        triggers::Dict{AbstractString, AbstractString}=@d("value"=>"change"),
+        doc=md"""A dict where the keys are attributes/properties and the values are
+                 events that trigger re-reads. Note that the attributes/properties
+                 are on the DOM node and not on the `Tile`."""
+    )
+    kwarg(
+        selector::AbstractString="::parent",
+        doc="A CSS selector for the element to watch."
+        )
+end
+
+default_intent(::WithStates) = identity
+
+render(t::WithStates, state) =
+    render(t.tile, state) <<
+        Elem(
+            "watch-states"; :triggers=>t.triggers, attributes=@d(
                 :selector=>t.selector,
             )
         )

--- a/src/basics/behavior.jl
+++ b/src/basics/behavior.jl
@@ -13,36 +13,6 @@ export hasstate,
 
 wrapbehavior(x::Behavior) = x
 
-@api hasstate => (WithState <: Behavior) begin
-    doc("Watch for changes to an attribute/property.")
-    arg(tile::Tile, doc="Tile to watch.")
-    kwarg(
-        attr::AbstractString="value",
-        doc=md"""The attribute/property to watch. Note that this is the property
-                 of the DOM node and not of the `Tile`."""
-    )
-    kwarg(
-        selector::AbstractString="::parent",
-        doc="A CSS selector for the element to watch."
-        )
-    kwarg(
-        trigger::AbstractString="change",
-        doc="The event that triggers a re-read of the attribute/property."
-    )
-end
-
-default_intent(::WithState) = identity
-
-render(t::WithState, state) =
-    render(t.tile, state) <<
-        Elem(
-            "watch-state", attributes=@d(
-                :attr=>t.attr,
-                :trigger=>t.trigger,
-                :selector=>t.selector,
-            )
-        )
-
 @api hasstates => (WithStates <: Behavior) begin
     doc("Watch for changes to attributes/properties.")
     arg(tile::Tile, doc="Tile to watch.")
@@ -67,6 +37,11 @@ render(t::WithStates, state) =
                 :selector=>t.selector,
             )
         )
+
+@doc "Watch for changes to an attribute/property." ->
+function hasstate(tile::Tile; attr::AbstractString="value", trigger::AbstractString="change", selector::AbstractString="::parent")
+    hasstates(tile; triggers=Dict(attr=>trigger), selector=selector)
+end
 
 @api keypress => (Keypress <: Behavior) begin
     doc("A keypress listener.")

--- a/src/library/widgets.jl
+++ b/src/library/widgets.jl
@@ -89,10 +89,18 @@ wrapbehavior(b::Button) =
         secondaryprogress::Real=0,
         doc="Highlight the slider bar from the beginning to this value."
     )
+    kwarg(
+        immediate::Bool=false,
+        doc="""If set to true, also trigger while the user is dragging the slider.
+        Due to the JavaScript implementation, this causes repeats in the subscribed
+        values when the text box is edited. Use `droprepeats` from `Reactive.jl`
+        to remove them."""
+    )
 end
 
 wrapbehavior(s::Slider) =
-    intent(ToType{eltype(s.range)}(), hasstate(s))
+    intent(ToType{eltype(s.range)}(),
+           s.immediate ? hasstates(s, triggers=Dict("value"=>"change", "immediateValue"=>"immediate-value-change")) : hasstate(s))
 
 render(s::Slider, state) =
     Elem("paper-slider", attributes=@d(


### PR DESCRIPTION
This PR adds two new things to Escher.jl.

The first is a slight reworking of `hasstate`, leading to the new function `hasstates`. The function `hasstates` is similar to `hasstate`, but takes a `Dict` of attribute / event pairs as input and watches all of them. This allows for more complex observations.

The second is a new keyword `immediate` on `slider`. If this is set to `true`, the `slider` will watch both the `value` and the `immediateValue` properties using `hasstates`. This allows the signal to be updated immediately while the user drags the slider. The default value of `immediate` is `false`.

This PR effectively solves https://github.com/shashi/Escher.jl/issues/147. All one has to do now is `slider(r, immediate=true)`. 

This PR is ready for review / merging.