### PR TITLE
Easy rendering of subscriptions

### DIFF
--- a/src/basics/signal.jl
+++ b/src/basics/signal.jl
@@ -347,6 +347,9 @@ render(sig::Subscription, state) =
 
 (>>>)(t::Tile, s::Union{Signal, Collector}) = subscribe(s, t)
 
+# This allows easy rendering of subscriptions
+convert(::Type{Node}, sub::Subscription) = render(sub, Dict())
+
 import Base.Random: UUID, uuid4
 
 const object_to_id = Dict()
@@ -372,4 +375,3 @@ end
 Given the unique ID created by makeid, return the object associated with it.
 """
 fromid(id) = id_to_object[id]
-


### PR DESCRIPTION
This PR adds a single line to Escher.jl: `convert(::Type{Node}, sub::Subscription) = render(sub, Dict())`. That line allows a `Subscription` to be used directly with  `<<` without a user having to call `render` on it directly.

I'd argue that this is useful, as some subscriptions can already be used with `<<` -- see `dropdownmenu`, for instance. My motivation here was to make subscriptions in other packages, like ThreeJS.jl, easier.

This PR is ready for review / merging.