### PR TITLE
Text about Gadfly requirement for plot examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ Move to a directory from which you want to serve Escher UI files.
 ```julia
 julia> cd(Pkg.dir("Escher", "examples"))
 ```
+Note:
+Example files which include plots, such as plotting.jl, also require the Gadfly package to be installed.
+```julia
+julia> Pkg.add("Gadfly")
+```
+
 Start the Escher Server.
 ```julia
 julia> escher_serve()


### PR DESCRIPTION
With a fresh Julia install and minimal packages installed prior to installing Escher and running examples, plotting.jl example returned an error due to missing Gadfly package.

This is a small change to the README to explicitly note this requirement.