### PR TITLE
Fixed follow-up bug to watch! and trigger!

### DIFF
--- a/assets/behavior.html
+++ b/assets/behavior.html
@@ -13,8 +13,7 @@ Polymer({
 
   properties: {
     triggers: {
-      type: Object,
-      value: {value: "change"}
+      type: Object
     }
   },
 
@@ -131,8 +130,9 @@ Polymer({
 
           var result = {}
           for(var i=0, l=self.signals.length; i < l; i++) {
-            var name = self.signals[i];
-            result[name] = Polymer.dom(elem).querySelector("#signal-" + name).getValue("value")
+            var name = self.signals[i]
+            var signal = Polymer.dom(elem).querySelector("#signal-" + name)
+            result[name] = signal.getValue(Object.keys(signal.triggers)[0]) // the signal should only have a single trigger
           }
           result[ev.detail.name] = ev.detail.value
           result._trigger = ev.detail.name

--- a/examples/checkboxes.jl
+++ b/examples/checkboxes.jl
@@ -1,0 +1,22 @@
+function main(window)
+    push!(window.assets, "widgets")
+
+    inp = Signal(Dict())
+
+    s = Escher.sampler()
+    form = vbox(
+        h1("How would you like your pizza?"),
+        trigger!(s, watch!(s, :pepperoni, checkbox("Pepperoni?"))),
+        trigger!(s, watch!(s, :mushrooms, checkbox("Mushrooms?"))),
+        trigger!(s, watch!(s, :peppers, checkbox("Peppers?"))),
+        trigger!(s, watch!(s, :anchovies, checkbox("Anchovies?"))),
+    ) |> maxwidth(400px)
+
+    map(inp) do dict
+        vbox(
+            intent(s, form) >>> inp,
+            vskip(2em),
+            string(dict)
+        ) |> Escher.pad(2em)
+    end
+end


### PR DESCRIPTION
This is a further fix for https://github.com/shashi/Escher.jl/pull/186. That PR fixed `watch!` and `trigger!` for most widgets, but apparently not all as I found out. This PR fixes it for other widgets like checkbox.

I've also added a new example -- checkboxes.jl -- that demonstrate using a group of checkboxes, all of which are watched and triggered.

@shashi Check out checkboxes.jl. If one wants a group of triggerable and watched checkboxes, the idiom is currently `trigger!(s, watch!(s, :name, checkbox(...)))`. Should we make a function that combines `trigger!` and `watch!`, or just leave it like this?