### PR TITLE
Fix include path

### DIFF
--- a/examples/graphics.jl
+++ b/examples/graphics.jl
@@ -1,4 +1,4 @@
-include("helpers/listing.jl")
+include("user-guide/helpers/listing.jl")
 
 function main(window)
     push!(window.assets, "widgets")


### PR DESCRIPTION
It seems this file moved into a subfolder user-guide. If you're following the README, you have cd'd into `/examples` so this extra part is necessary.